### PR TITLE
fix encoding strings when length is a multiple of 128

### DIFF
--- a/pyproto/__init__.py
+++ b/pyproto/__init__.py
@@ -128,7 +128,7 @@ class ProtoWriter:
 
     def writeVarint(self, vint):
         vint = vint & 0xFFFFFFFF
-        while vint > 0x80:
+        while vint >= 0x80:
             self.write0((vint & 0x7F) | 0x80)
             vint >>= 7
         self.write0(vint & 0x7F)


### PR DESCRIPTION
if the length of a string is exactly 128, the length prefix is wrongly written as `00` instead of `8001`. this fixes that.

minimal reproducer:

    from pyproto import ProtoBuf
    print(ProtoBuf({1: "A"*128}).toBuf().hex())

before: 0a004141414141414141...
after:  0a80014141414141414141...